### PR TITLE
Add Main Layout With Tab Navigation

### DIFF
--- a/lib/core/utils/di/di.config.dart
+++ b/lib/core/utils/di/di.config.dart
@@ -36,6 +36,8 @@ import '../../../features/auth/presentation/view_model/signin/signin_cubit.dart'
     as _i703;
 import '../../../features/auth/presentation/view_model/signup/signup_cubit.dart'
     as _i122;
+import '../../../features/main_layout/presentation/view_model/main_layout_cubit.dart'
+    as _i233;
 import '../bloc_observer/bloc_observer_service.dart' as _i649;
 import '../flutter_secure_storage_module.dart' as _i712;
 import '../logging/logger_module.dart' as _i470;
@@ -55,6 +57,7 @@ extension GetItInjectableX on _i174.GetIt {
     final secureStorageModule = _$SecureStorageModule();
     final loggerModule = _$LoggerModule();
     final dioModule = _$DioModule();
+    gh.factory<_i233.MainLayoutCubit>(() => _i233.MainLayoutCubit());
     gh.singleton<_i943.ApiManager>(() => _i943.ApiManager());
     gh.lazySingleton<_i59.FirebaseAuth>(() => firebaseModule.auth);
     gh.lazySingleton<_i974.FirebaseFirestore>(() => firebaseModule.firestore);

--- a/lib/core/utils/routes/app_routes.dart
+++ b/lib/core/utils/routes/app_routes.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:library_app/core/utils/routes/route_name.dart';
+import 'package:library_app/features/main_layout/presentation/view/main_layout.dart';
 
 import '../../../features/auth/presentation/view/screens/login_screen.dart';
 import '../../../features/auth/presentation/view/screens/signup_screen.dart';
@@ -22,6 +23,11 @@ class AppRoutes {
       case RouteName.homeScreen:
         return _handelMaterialPageRoute(
           widget: HomeScreen(),
+          settings: settings,
+        );
+      case RouteName.mainLayout:
+        return _handelMaterialPageRoute(
+          widget: MainLayout(),
           settings: settings,
         );
       default:

--- a/lib/core/utils/routes/route_name.dart
+++ b/lib/core/utils/routes/route_name.dart
@@ -2,4 +2,5 @@ class RouteName {
   static const String loginScreen = '/loginScreen';
   static const String signUpScreen = '/signUpScreen';
   static const String homeScreen = '/homeScreen';
+  static const String mainLayout = '/mainLayout';
 }

--- a/lib/features/auth/presentation/view/screens/login_screen.dart
+++ b/lib/features/auth/presentation/view/screens/login_screen.dart
@@ -34,7 +34,7 @@ class LoginScreen extends StatelessWidget {
                       if (state.signinState is BaseSuccessState) {
                         Navigator.pushReplacementNamed(
                           context,
-                          RouteName.homeScreen,
+                          RouteName.mainLayout,
                         );
                       } else if (state.signinState is BaseErrorState) {
                         Navigator.of(context, rootNavigator: true).maybePop();

--- a/lib/features/library/presentaion/my_library_screen.dart
+++ b/lib/features/library/presentaion/my_library_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class MyLibraryScreen extends StatelessWidget {
+  const MyLibraryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Text(
+          'Welcome to My Library',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/main_layout/presentation/view/main_layout.dart
+++ b/lib/features/main_layout/presentation/view/main_layout.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:library_app/features/home/presentation/view/home_screen.dart';
+import 'package:library_app/features/library/presentaion/my_library_screen.dart';
+import 'package:library_app/features/search/presentation/view/search_screen.dart';
+
+import '../../../../core/utils/di/di.dart';
+import '../../../profile/presentation/view/profile_screen.dart';
+import '../view_model/main_layout_cubit.dart';
+import '../view_model/main_layout_state.dart';
+
+class MainLayout extends StatelessWidget {
+  MainLayout({super.key});
+
+  final viewModel = getIt<MainLayoutCubit>();
+
+  final Map<MainLayoutTabs, WidgetBuilder> tabs = {
+    MainLayoutTabs.home: (_) => HomeScreen(),
+    MainLayoutTabs.search: (_) => SearchScreen(),
+    MainLayoutTabs.myLibrary: (_) => MyLibraryScreen(),
+    MainLayoutTabs.profile: (_) => ProfileScreen(),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => viewModel,
+      child: BlocBuilder<MainLayoutCubit, MainLayoutState>(
+        builder: (context, state) {
+          final selectedTab = state.selectedTab;
+
+          return Scaffold(
+            body: tabs[selectedTab]?.call(context) ?? const SizedBox.shrink(),
+            bottomNavigationBar: ValueListenableBuilder<bool>(
+              valueListenable: viewModel.scrollVisibilityController,
+              builder: (_, visible, child) {
+                return AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  height: visible ? kBottomNavigationBarHeight : 0,
+                  child: Wrap(
+                    children: [
+                      Offstage(
+                        offstage: !visible,
+                        child: BottomNavigationBar(
+                          currentIndex: selectedTab.index,
+                          onTap: (value) {
+                            context.read<MainLayoutCubit>().doIntent(
+                              ChangeSelectedTab(MainLayoutTabs.values[value]),
+                            );
+                          },
+                          items: [
+                            BottomNavigationBarItem(
+                              icon: Icon(Icons.home),
+                              label: "Home",
+                            ),
+                            BottomNavigationBarItem(
+                              icon: Icon(Icons.search),
+                              label: "Search",
+                            ),
+                            BottomNavigationBarItem(
+                              icon: Icon(Icons.book),
+                              label: "My Library",
+                            ),
+                            BottomNavigationBarItem(
+                              icon: Icon(Icons.person),
+                              label: "Profile",
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/main_layout/presentation/view_model/main_layout_cubit.dart
+++ b/lib/features/main_layout/presentation/view_model/main_layout_cubit.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+import '../../../../core/base/base_state.dart';
+import 'main_layout_state.dart';
+
+@injectable
+class MainLayoutCubit extends Cubit<MainLayoutState> {
+  final scrollVisibilityController = ValueNotifier<bool>(true);
+  MainLayoutCubit()
+    : super(
+        MainLayoutState(
+          baseState: BaseInitialState(),
+          selectedTab: MainLayoutTabs.home,
+        ),
+      );
+
+  void _changeTab(MainLayoutTabs tab) {
+    emit(state.copyWith(selectedTab: tab));
+  }
+
+  void _changeTabWithCategory(MainLayoutTabs tab, int index) {
+    emit(state.copyWith(selectedTab: tab, categoryIndex: index));
+  }
+
+  void doIntent(MainLayoutAction action) {
+    switch (action) {
+      case ChangeSelectedTab():
+        _changeTab(action.selectedTab);
+      case ChangeTabWithCategoryIndex():
+        _changeTabWithCategory(action.selectedTab, action.categoryIndex);
+    }
+  }
+
+  void dispose() {
+    scrollVisibilityController.dispose();
+    super.close();
+  }
+}

--- a/lib/features/main_layout/presentation/view_model/main_layout_state.dart
+++ b/lib/features/main_layout/presentation/view_model/main_layout_state.dart
@@ -1,0 +1,47 @@
+import 'package:equatable/equatable.dart';
+
+import '../../../../../core/base/base_state.dart';
+
+enum MainLayoutTabs { home, search, myLibrary, profile }
+
+class MainLayoutState extends Equatable {
+  final BaseState baseState;
+  final MainLayoutTabs selectedTab;
+  final int? categoryIndex;
+
+  const MainLayoutState({
+    required this.baseState,
+    required this.selectedTab,
+    this.categoryIndex,
+  });
+
+  @override
+  List<Object?> get props => [baseState, selectedTab, categoryIndex];
+
+  MainLayoutState copyWith({
+    BaseState? baseState,
+    MainLayoutTabs? selectedTab,
+    int? categoryIndex,
+  }) {
+    return MainLayoutState(
+      baseState: baseState ?? this.baseState,
+      selectedTab: selectedTab ?? this.selectedTab,
+      categoryIndex: categoryIndex ?? this.categoryIndex,
+    );
+  }
+}
+
+sealed class MainLayoutAction {}
+
+class ChangeSelectedTab extends MainLayoutAction {
+  final MainLayoutTabs selectedTab;
+
+  ChangeSelectedTab(this.selectedTab);
+}
+
+class ChangeTabWithCategoryIndex extends MainLayoutAction {
+  final MainLayoutTabs selectedTab;
+  final int categoryIndex;
+
+  ChangeTabWithCategoryIndex(this.selectedTab, this.categoryIndex);
+}

--- a/lib/features/profile/presentation/view/profile_screen.dart
+++ b/lib/features/profile/presentation/view/profile_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Text(
+          'Welcome to Profile',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/search/presentation/view/search_screen.dart
+++ b/lib/features/search/presentation/view/search_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class SearchScreen extends StatelessWidget {
+  const SearchScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Text(
+          'Search functionality is not implemented yet.',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `MainLayout` feature, which serves as the main navigation hub of the application. It includes the addition of navigation tabs, routing updates, and the creation of several placeholder screens. The most important changes include the implementation of the `MainLayout` UI and logic, updates to the routing system, and the addition of new screens for "My Library," "Profile," and "Search."

### MainLayout Feature Implementation:
* Created the `MainLayout` widget with a bottom navigation bar to switch between tabs (`Home`, `Search`, `My Library`, and `Profile`) and integrated it with the `MainLayoutCubit` for state management. (`lib/features/main_layout/presentation/view/main_layout.dart`)
* Added `MainLayoutCubit` and `MainLayoutState` to manage the selected tab and handle navigation actions. (`lib/features/main_layout/presentation/view_model/main_layout_cubit.dart`, `lib/features/main_layout/presentation/view_model/main_layout_state.dart`) [[1]](diffhunk://#diff-7edfb8b29f510715a8452a99d14c89810488a579fedfae9d356d344967fdc6faR1-R39) [[2]](diffhunk://#diff-2bf2d8e9e77ca51c2207cda8fc0c13b210aa8a9e2e5a9d1d85eb5b3f931c9188R1-R47)

### Routing Updates:
* Updated the routing system to include the `MainLayout` route and redirect successful login attempts to it instead of the `HomeScreen`. (`lib/core/utils/routes/app_routes.dart`, `lib/core/utils/routes/route_name.dart`, `lib/features/auth/presentation/view/screens/login_screen.dart`) [[1]](diffhunk://#diff-8e1d116f5ff3454d7bf578c0b0ccac8cbc56944e4ac1a1c2b4c5129e5c05cc35R4) [[2]](diffhunk://#diff-8e1d116f5ff3454d7bf578c0b0ccac8cbc56944e4ac1a1c2b4c5129e5c05cc35R28-R32) [[3]](diffhunk://#diff-e51764c4cddcb0a1ba3f4b828b382757f298dfc04bb7450b009d82e9c54cbef4R5) [[4]](diffhunk://#diff-c602cbd1b4bb080921ba3b2746844fd3d549740a7418662e56c316d24efd80aaL37-R37)

### New Screens:
* Added placeholder screens for `My Library`, `Profile`, and `Search` with basic UI elements. (`lib/features/library/presentaion/my_library_screen.dart`, `lib/features/profile/presentation/view/profile_screen.dart`, `lib/features/search/presentation/view/search_screen.dart`) [[1]](diffhunk://#diff-5096322283b19e3030dd6760219e009959a1878b8fffedb058e7f7af919c6434R1-R17) [[2]](diffhunk://#diff-72ee725503354f21511e51fb5184fe1a2f545a0b495f52e168272dec97127777R1-R17) [[3]](diffhunk://#diff-0dd9e8cfd35acdfdc3c1dfb9f8df0737bd310da4abcda6b984f3f3a2ec7032c3R1-R17)

### Dependency Injection:
* Registered `MainLayoutCubit` in the dependency injection configuration. (`lib/core/utils/di/di.config.dart`) [[1]](diffhunk://#diff-b3e417004ed21ee34ae65133a680e832424ff016199927a2727f357744eaf351R39-R40) [[2]](diffhunk://#diff-b3e417004ed21ee34ae65133a680e832424ff016199927a2727f357744eaf351R60)