### PR TITLE
Add Profile Feature 

### DIFF
--- a/lib/core/utils/di/di.config.dart
+++ b/lib/core/utils/di/di.config.dart
@@ -27,6 +27,8 @@ import '../../../features/auth/data/data_source/remote/auth_remote_data_source_i
     as _i212;
 import '../../../features/auth/data/repo_impl/auth_repo_impl.dart' as _i822;
 import '../../../features/auth/domain/repo/auth_repo.dart' as _i913;
+import '../../../features/auth/domain/usecase/get_current_user_data_use_case.dart'
+    as _i721;
 import '../../../features/auth/domain/usecase/get_user_state_use_case.dart'
     as _i330;
 import '../../../features/auth/domain/usecase/signin_use_case.dart' as _i612;
@@ -99,6 +101,8 @@ import '../../../features/library/presentaion/view_model/library_books/library_b
     as _i635;
 import '../../../features/main_layout/presentation/view_model/main_layout_cubit.dart'
     as _i233;
+import '../../../features/profile/presentation/view_model/profile_cubit.dart'
+    as _i782;
 import '../../../features/search/data/data_source/contract/search_remote_data_source.dart'
     as _i424;
 import '../../../features/search/data/data_source/remote/search_remote_data_source_impl.dart'
@@ -246,6 +250,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i955.SignupUseCase>(
       () => _i955.SignupUseCase(gh<_i913.AuthRepo>()),
     );
+    gh.factory<_i721.GetCurrentUserDataUseCase>(
+      () => _i721.GetCurrentUserDataUseCase(gh<_i913.AuthRepo>()),
+    );
     gh.factory<_i122.SignupCubit>(
       () => _i122.SignupCubit(gh<_i955.SignupUseCase>(), gh<_i437.Validator>()),
     );
@@ -287,6 +294,12 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i413.GetAllBooksUseCase>(),
         gh<_i247.GetBooksByCategoryUseCase>(),
         gh<_i304.GetBooksByRatingUseCase>(),
+      ),
+    );
+    gh.factory<_i782.ProfileCubit>(
+      () => _i782.ProfileCubit(
+        gh<_i721.GetCurrentUserDataUseCase>(),
+        gh<_i716.SignoutUseCase>(),
       ),
     );
     gh.factory<_i977.BookDetailsCubit>(

--- a/lib/features/auth/data/data_source/contract/auth_remote_data_source.dart
+++ b/lib/features/auth/data/data_source/contract/auth_remote_data_source.dart
@@ -1,3 +1,5 @@
+import 'package:library_app/features/book_details/data/model/user_dto.dart';
+
 import '../../model/signin_request_dto.dart';
 import '../../model/signup_request_dto.dart';
 
@@ -6,4 +8,5 @@ abstract class AuthRemoteDataSource {
   Future<void> signUp(SignupRequestDto request);
   Future<void> signIn(SigninRequestDto request);
   Future<void> signOut();
+  Future<UserDto> getCurrentUserData(String userId);
 }

--- a/lib/features/auth/data/data_source/remote/auth_remote_data_source_impl.dart
+++ b/lib/features/auth/data/data_source/remote/auth_remote_data_source_impl.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:injectable/injectable.dart';
 import 'package:library_app/features/auth/data/data_source/contract/auth_remote_data_source.dart';
 import 'package:library_app/features/auth/data/model/signin_request_dto.dart';
+import 'package:library_app/features/book_details/data/model/user_dto.dart';
 
 import '../../model/signup_request_dto.dart';
 
@@ -44,5 +45,11 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   @override
   Future<void> signOut() async {
     await FirebaseAuth.instance.signOut();
+  }
+
+  @override
+  Future<UserDto> getCurrentUserData(String userId) async {
+    final doc = await _firestore.collection('users').doc(userId).get();
+    return UserDto.fromFirestore(doc.data()!, doc.id);
   }
 }

--- a/lib/features/auth/data/repo_impl/auth_repo_impl.dart
+++ b/lib/features/auth/data/repo_impl/auth_repo_impl.dart
@@ -6,6 +6,7 @@ import 'package:library_app/features/auth/data/data_source/contract/auth_local_d
 import 'package:library_app/features/auth/data/data_source/contract/auth_remote_data_source.dart';
 import 'package:library_app/features/auth/domain/entity/signin_request_entity.dart';
 import 'package:library_app/features/auth/domain/repo/auth_repo.dart';
+import 'package:library_app/features/book_details/domain/entity/user_entity.dart';
 
 import '../../domain/entity/signup_request_entity.dart';
 import '../model/signin_request_dto.dart';
@@ -55,6 +56,15 @@ class AuthRepoImpl implements AuthRepo {
     return await _apiManager.execute<void>(() async {
       await _authRemoteDataSource.signOut();
       await _authLocalDataSource.clearUserId();
+    });
+  }
+
+  @override
+  Future<Result<UserEntity>> getCurrentUserData() async {
+    return await _apiManager.execute<UserEntity>(() async {
+      final userId = await _authLocalDataSource.getUserId();
+      final user = await _authRemoteDataSource.getCurrentUserData(userId!);
+      return user.toEntity();
     });
   }
 }

--- a/lib/features/auth/domain/repo/auth_repo.dart
+++ b/lib/features/auth/domain/repo/auth_repo.dart
@@ -1,4 +1,5 @@
 import 'package:library_app/core/utils/networking/api_result.dart';
+import 'package:library_app/features/book_details/domain/entity/user_entity.dart';
 
 import '../entity/signin_request_entity.dart';
 import '../entity/signup_request_entity.dart';
@@ -8,4 +9,5 @@ abstract class AuthRepo {
   Future<Result<void>> signUp(SignupRequestEntity request);
   Future<Result<void>> signIn(SigninRequestEntity request);
   Future<Result<void>> signOut();
+  Future<Result<UserEntity>> getCurrentUserData();
 }

--- a/lib/features/auth/domain/usecase/get_current_user_data_use_case.dart
+++ b/lib/features/auth/domain/usecase/get_current_user_data_use_case.dart
@@ -1,0 +1,15 @@
+import 'package:injectable/injectable.dart';
+import 'package:library_app/features/auth/domain/repo/auth_repo.dart';
+
+import '../../../../core/utils/networking/api_result.dart';
+import '../../../book_details/domain/entity/user_entity.dart';
+
+@injectable
+class GetCurrentUserDataUseCase {
+  final AuthRepo _authRepo;
+  GetCurrentUserDataUseCase(this._authRepo);
+
+  Future<Result<UserEntity>> call() async {
+    return await _authRepo.getCurrentUserData();
+  }
+}

--- a/lib/features/profile/presentation/view/profile_screen.dart
+++ b/lib/features/profile/presentation/view/profile_screen.dart
@@ -1,15 +1,72 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:library_app/core/utils/di/di.dart';
+
+import '../../../../core/base/base_state.dart';
+import '../../../../core/utils/routes/route_name.dart';
+import '../../../book_details/domain/entity/user_entity.dart';
+import '../view_model/profile_cubit.dart';
+import '../view_model/profile_state.dart';
 
 class ProfileScreen extends StatelessWidget {
-  const ProfileScreen({super.key});
+  ProfileScreen({super.key});
+
+  final viewModel = getIt<ProfileCubit>();
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: Text(
-          'Welcome to Profile',
-          style: Theme.of(context).textTheme.bodyLarge,
+    return BlocProvider(
+      create: (context) => viewModel..doIntent(GetProfile()),
+      child: Scaffold(
+        body: BlocBuilder<ProfileCubit, ProfileState>(
+          builder: (context, state) {
+            final baseState = state.profileState;
+
+            if (baseState is BaseLoadingState) {
+              return const Center(child: CircularProgressIndicator());
+            } else if (baseState is BaseSuccessState<UserEntity>) {
+              final user = baseState.data;
+
+              return Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const CircleAvatar(
+                      radius: 50,
+                      backgroundImage: NetworkImage(
+                        'https://cdn.vectorstock.com/i/1000x1000/89/97/man-male-avatar-silhouette-person-icon-vector-10248997.webp',
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      '${user!.firstName ?? ''} ${user.lastName ?? ''}',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      user.email ?? '',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: () {
+                        context.read<ProfileCubit>().doIntent(Logout());
+                        Navigator.pushReplacementNamed(
+                          context,
+                          RouteName.loginScreen,
+                        );
+                      },
+                      child: const Text('Logout'),
+                    ),
+                  ],
+                ),
+              );
+            } else if (baseState is BaseErrorState) {
+              return Center(child: Text(baseState.errorMessage));
+            }
+
+            return const SizedBox(); // Empty state or initial state
+          },
         ),
       ),
     );

--- a/lib/features/profile/presentation/view_model/profile_cubit.dart
+++ b/lib/features/profile/presentation/view_model/profile_cubit.dart
@@ -1,0 +1,59 @@
+import 'package:bloc/bloc.dart';
+import 'package:injectable/injectable.dart';
+import 'package:library_app/core/base/base_state.dart';
+import 'package:library_app/features/auth/domain/usecase/get_current_user_data_use_case.dart';
+import 'package:library_app/features/profile/presentation/view_model/profile_state.dart';
+
+import '../../../../core/utils/networking/api_result.dart';
+import '../../../auth/domain/usecase/signout_use_case.dart';
+
+@injectable
+class ProfileCubit extends Cubit<ProfileState> {
+  final GetCurrentUserDataUseCase _getCurrentUserDataUseCase;
+  final SignoutUseCase _signoutUseCase;
+  ProfileCubit(this._getCurrentUserDataUseCase, this._signoutUseCase)
+    : super(ProfileState(profileState: BaseInitialState()));
+
+  Future<void> _getCurrentUserData() async {
+    emit(state.copyWith(profileState: BaseLoadingState()));
+    final result = await _getCurrentUserDataUseCase();
+    switch (result) {
+      case SuccessResult():
+        emit(state.copyWith(profileState: BaseSuccessState(data: result.data)));
+      case FailureResult():
+        emit(
+          state.copyWith(
+            profileState: BaseErrorState(
+              errorMessage: result.exception.toString(),
+            ),
+          ),
+        );
+    }
+  }
+
+  Future<void> _logout() async {
+    emit(state.copyWith(profileState: BaseLoadingState()));
+    final result = await _signoutUseCase();
+    switch (result) {
+      case SuccessResult():
+        emit(state.copyWith(profileState: BaseSuccessState()));
+      case FailureResult():
+        emit(
+          state.copyWith(
+            profileState: BaseErrorState(
+              errorMessage: result.exception.toString(),
+            ),
+          ),
+        );
+    }
+  }
+
+  void doIntent(ProfileAction action) {
+    switch (action) {
+      case GetProfile():
+        _getCurrentUserData();
+      case Logout():
+        _logout();
+    }
+  }
+}

--- a/lib/features/profile/presentation/view_model/profile_state.dart
+++ b/lib/features/profile/presentation/view_model/profile_state.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+import 'package:library_app/core/base/base_state.dart';
+
+class ProfileState extends Equatable {
+  final BaseState? profileState;
+  final BaseState? logoutState;
+
+  const ProfileState({this.profileState, this.logoutState});
+
+  @override
+  List<Object?> get props => [profileState, logoutState];
+
+  ProfileState copyWith({BaseState? profileState, BaseState? logoutState}) {
+    return ProfileState(
+      profileState: profileState ?? this.profileState,
+      logoutState: logoutState ?? this.logoutState,
+    );
+  }
+}
+
+sealed class ProfileAction {}
+
+class GetProfile extends ProfileAction {}
+
+class Logout extends ProfileAction {}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
     source: hosted
     version: "2.13.0"
   bloc:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: bloc
       sha256: "52c10575f4445c61dd9e0cafcc6356fdd827c4c64dd7945ef3c4105f6b6ac189"
@@ -242,7 +242,7 @@ packages:
     source: hosted
     version: "3.1.0"
   dio:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: dio
       sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"


### PR DESCRIPTION
This pull request introduces a new feature to fetch and display the current user's profile data in the Profile screen, along with the ability to log out. It includes changes across multiple layers of the application, such as data sources, repositories, use cases, and the presentation layer. The key changes are grouped into the following themes:

### Data Layer Enhancements:
* Added a new method `getCurrentUserData(String userId)` to the `AuthRemoteDataSource` contract and implemented it in `AuthRemoteDataSourceImpl` to fetch user data from Firestore. (`lib/features/auth/data/data_source/contract/auth_remote_data_source.dart` - [[1]](diffhunk://#diff-1c907a8be40cec87e3e6283349cb071994cb7f76ede0ac2487f4e5598d9971d7R11) `lib/features/auth/data/data_source/remote/auth_remote_data_source_impl.dart` - [[2]](diffhunk://#diff-121c2868f2c8e962096f73d5a40594b754cc9502b4bf069b18d8627d3f961ea5R49-R54)
* Updated `AuthRepo` and `AuthRepoImpl` to include the `getCurrentUserData` method, which wraps the remote data source call in a `Result` object. (`lib/features/auth/domain/repo/auth_repo.dart` - [[1]](diffhunk://#diff-29dad70226bbd5815a0f8af144ea5234638260d77d14aec07b43631a5d48eabeR12) `lib/features/auth/data/repo_impl/auth_repo_impl.dart` - [[2]](diffhunk://#diff-001dc92ad457024b6eaab3c8cb91e2bc376e50fd5bd24bbee449268513df7cd5R61-R69)

### Domain Layer Additions:
* Introduced a new use case, `GetCurrentUserDataUseCase`, to encapsulate the logic for fetching the current user's data via the repository. (`lib/features/auth/domain/usecase/get_current_user_data_use_case.dart` - [lib/features/auth/domain/usecase/get_current_user_data_use_case.dartR1-R15](diffhunk://#diff-ca6a119346bab6cdea2b0f73e6e41e606b9bb2299dbeb4b2cf8367a733cee6ffR1-R15))

### Dependency Injection Updates:
* Registered the new `GetCurrentUserDataUseCase` and `ProfileCubit` in the dependency injection configuration. (`lib/core/utils/di/di.config.dart` - [[1]](diffhunk://#diff-b3e417004ed21ee34ae65133a680e832424ff016199927a2727f357744eaf351R253-R255) [[2]](diffhunk://#diff-b3e417004ed21ee34ae65133a680e832424ff016199927a2727f357744eaf351R299-R304)

### Profile Screen Implementation:
* Refactored the `ProfileScreen` to use `ProfileCubit` for managing state. It now displays the user's name, email, and avatar, and includes a logout button. (`lib/features/profile/presentation/view/profile_screen.dart` - [lib/features/profile/presentation/view/profile_screen.dartR2-R69](diffhunk://#diff-72ee725503354f21511e51fb5184fe1a2f545a0b495f52e168272dec97127777R2-R69))

### State Management for Profile:
* Added `ProfileCubit` to handle fetching user data and logging out, along with a corresponding `ProfileState` class to manage the UI state. (`lib/features/profile/presentation/view_model/profile_cubit.dart` - [[1]](diffhunk://#diff-a4176b5147a03aa8ca38cb3357d0b247ef3c588054daa84db600ceaed4a77064R1-R59) `lib/features/profile/presentation/view_model/profile_state.dart` - [[2]](diffhunk://#diff-e9af046c4106cdebf6195cab32e74dcfa6c09cd6d185c501ee27d2de0d36307bR1-R25)